### PR TITLE
アカウント連携のロジックをリファクタリング

### DIFF
--- a/src/app/_components/AccountLinkingSection/AccountLinkingToggle/AccountLinkingToggle.tsx
+++ b/src/app/_components/AccountLinkingSection/AccountLinkingToggle/AccountLinkingToggle.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { AccountProvider } from '@/app/_components/AccountLinkingSection/AccountLinkingSection';
+import { ConfirmDialog } from '@/app/_components/AccountLinkingSection/AccountLinkingToggle/ConfirmDialog';
+import { action } from '@/app/actions';
+import { Switch } from '@/components/ui/switch';
+import { signIn } from 'next-auth/react';
+import { useState, type JSX } from 'react';
+
+type Props = {
+  provider: AccountProvider;
+  isToggleOn: boolean;
+  isDisabled: boolean;
+};
+
+const getProviderName = (provider: AccountProvider): string => {
+  switch (provider) {
+    case 'google':
+      return 'Google';
+    case 'line':
+      return 'LINE';
+    default:
+      return '';
+  }
+};
+
+export const AccountLinkingToggle = ({
+  provider,
+  isToggleOn,
+  isDisabled,
+}: Props): JSX.Element => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const providerName = getProviderName(provider);
+
+  const toggleSwitch = async () => {
+    if (isToggleOn) {
+      setIsDialogOpen(true);
+    }
+    if (!isToggleOn) {
+      await signIn(provider);
+      action();
+    }
+  };
+
+  return (
+    <div className='flex mb-6'>
+      <Switch
+        checked={isToggleOn}
+        disabled={isDisabled}
+        onClick={toggleSwitch}
+      />
+      <label className='ml-4'>{`${providerName}アカウントを連携`}</label>
+      <ConfirmDialog
+        title={`${providerName}アカウント連携を解除しますか`}
+        provider={provider}
+        isOpen={isDialogOpen}
+        onClose={() => setIsDialogOpen(false)}
+        onClick={action}
+      />
+    </div>
+  );
+};

--- a/src/app/_components/AccountLinkingSection/AccountLinkingToggle/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/app/_components/AccountLinkingSection/AccountLinkingToggle/ConfirmDialog/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   Dialog,
   DialogClose,
@@ -7,16 +9,18 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { AccountProvider } from '@/app/_components/AccountLinkingSection/AccountLinkingSection';
+import { useState } from 'react';
 
 type Props = {
   title: string;
-  provider: string;
+  provider: AccountProvider;
   isOpen: boolean;
   onClose: () => void;
-  onToggle: () => void;
+  onClick: () => void;
 };
 
-async function deleteAccount(provider: string) {
+async function deleteAccount(provider: AccountProvider) {
   await fetch('api/account', {
     method: 'DELETE',
     body: JSON.stringify({ provider }),
@@ -28,9 +32,10 @@ export const ConfirmDialog = ({
   provider,
   isOpen,
   onClose,
-  onToggle,
+  onClick,
 }: Props): JSX.Element => {
-  // TODO: 送信中はボタンをdisabledにする
+  const [isLoading, setIsLoading] = useState(false);
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className='top-[0] translate-y-[0] sm:top-[50%] sm:max-w-[350px] sm:translate-y-[-50%]'>
@@ -39,17 +44,19 @@ export const ConfirmDialog = ({
         </DialogHeader>
         <DialogFooter className='mt-4 gap-x-0.5 gap-y-2'>
           <DialogClose asChild>
-            <Button type='button' variant='outline'>
+            <Button type='button' variant='outline' disabled={isLoading}>
               キャンセル
             </Button>
           </DialogClose>
           <Button
-            type='submit'
-            className='flex gap-2'
+            type='button'
+            disabled={isLoading}
             onClick={async () => {
+              setIsLoading(true);
               await deleteAccount(provider);
               onClose();
-              onToggle();
+              onClick();
+              setIsLoading(false);
             }}
           >
             <span>解除する</span>

--- a/src/app/_components/AccountLinkingSection/AccountLinkingToggle/ConfirmDialog/index.ts
+++ b/src/app/_components/AccountLinkingSection/AccountLinkingToggle/ConfirmDialog/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmDialog } from './ConfirmDialog';

--- a/src/app/_components/AccountLinkingSection/AccountLinkingToggle/index.ts
+++ b/src/app/_components/AccountLinkingSection/AccountLinkingToggle/index.ts
@@ -1,0 +1,1 @@
+export { AccountLinkingToggle } from './AccountLinkingToggle';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,14 +5,9 @@ import {
   LogoutButton,
   UserProfile,
 } from '@/app/_components';
-import { Provider } from '@/app/_components/AccountLinkingSection/AccountLinkingSection';
 import type { Session } from 'next-auth';
 import { headers } from 'next/headers';
 import type { JSX } from 'react';
-
-type ProviderObject = {
-  provider: Provider;
-};
 
 async function fetchSession(cookie: string): Promise<Session | null> {
   const response = await fetch(`${process.env.NEXTAUTH_URL}/api/auth/session`, {
@@ -22,18 +17,6 @@ async function fetchSession(cookie: string): Promise<Session | null> {
   });
   const session = (await response.json()) as Session;
   return Object.keys(session).length > 0 ? session : null;
-}
-
-async function fetchAccountProviders(
-  cookie: string
-): Promise<ProviderObject[]> {
-  const res = await fetch(`${process.env.NEXTAUTH_URL}/api/account`, {
-    method: 'GET',
-    headers: { cookie },
-    next: { tags: ['account'] },
-  });
-  if (!res.ok) return [];
-  return res.json();
 }
 
 type ValidSession = {
@@ -59,8 +42,6 @@ function isValidSession(session: Session | null): session is ValidSession {
 
 export default async function Home(): Promise<JSX.Element> {
   const session = await fetchSession(headers().get('cookie') ?? '');
-  const res = await fetchAccountProviders(headers().get('cookie') ?? '');
-  const providers = res.map((x) => x.provider);
 
   return (
     <main className='flex min-h-screen flex-col items-center justify-between p-24'>
@@ -71,7 +52,7 @@ export default async function Home(): Promise<JSX.Element> {
             email={session.user.email ?? ''}
             avatarUrl={session.user.image}
           />
-          <AccountLinkingSection accounts={providers} />
+          <AccountLinkingSection />
           <LogoutButton />
         </>
       ) : (


### PR DESCRIPTION
# 変更の概要

- ClientComponentの範囲をToggleSwitchに限定
- accountのデータフェッチをアカウント連携セクション内で行うように
- Providerが増えた場合を考慮